### PR TITLE
Add docker support for testing suite

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -10,3 +10,6 @@ COPY pnpm-lock.yaml /app
 RUN pnpm install
 
 COPY . /app
+
+RUN pnpm playwright install-deps
+RUN pnpm exec playwright install

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  lint:
+    build: .
+    command: pnpm run lint
+    volumes:
+      - /app/
+      - /app/node_modules
+  type-check:
+    build: .
+    command: pnpm run type-check
+    volumes:
+      - /app/
+      - /app/node_modules
+  jest:
+    build: .
+    command: pnpm run test
+    volumes:
+      - /app/
+      - /app/node_modules
+  end-to-end:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    command: pnpm run test:e2e
+    volumes:
+      - /app/
+      - /app/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
-version: "3"
+version: '3'
 services:
   web:
     build: .
     ports:
       - 3000:3000
+    command: pnpm run dev
     volumes:
       - /app/
       - /app/node_modules


### PR DESCRIPTION
This PR fixes https://github.com/gabrielreisn/stargazer-count/issues/2 by adding support for the following operations using docker:

- Listing (ESLint)
- Unit testing (Jest)
- Type checking analysis (Typescript)
- end-to-end testing (Playwright)

Making available the same functionalities as the CI pipeline